### PR TITLE
Added functions to comopute contingency tables and skills using finite-length time windows.

### DIFF
--- a/camel/skillscores.py
+++ b/camel/skillscores.py
@@ -9,7 +9,7 @@ All Other Rights Reserved.
 
 import pandas as pd
 import numpy as np
-from datetime import datetime,timedelta
+from datetime import datetime,timedelta,timezone
 
 def interpolate_dataframe_to_base(frame, baseFrame, method):
 	'''
@@ -64,6 +64,42 @@ def remove_gaps(modDF, obsDF, maxSeconds):
 
 	return obsDF.reindex(timeDF.index)
 
+def timestamp2datetime(timestamp,format="%Y-%m-%dT%H:%M:%SZ"):
+	datetimestamp = datetime.strptime(timestamp,format).replace(tzinfo=timezone.utc)
+	return datetimestamp
+
+def dBH_dt(df,compute_derivatives=False):
+        '''
+        Computes the magnititude of time derivatives of horizontal magnetic perturbations.
+        This is the parameter used in Pulkkinen et al (2013) that is compared against threshold values of 0.3 0.7, 1.1 and 1.5 nT/s.
+        Parameters: dataframe with tiemstampos, DeltaB components (Down, North, East) and (optional) time derivatives of the DeltaB components
+        Returns:
+                df_dbH_dt - dataframe with timestamps and dBH_dt.
+                      Timestamps are taken from existing dataframe if derivatives already exist.
+                      Time stamps are calculated as the average of adjacent time stamps if
+                        derivatives are calculated from raw DeltaB data.
+        '''
+        df_size = df.shape[0]
+        if "Derivative_DeltaB_East" in df.columns and "Derivative_DeltaB_North" in df.columns:
+                # if dataframes have the time derivatives already calculated
+                df_dBE_dt = np.array(df['Derivative_DeltaB_East'])
+                df_dBN_dt = np.array(df['Derivative_DeltaB_North'])
+                df_timestamp = np.array(df["timestamp"])
+                df_datetimes = np.array([timestamp2datetime(timestamp) for timestamp in df_timestamp])
+        else:
+                # dataframes with the raw DeltaB (magnetic perturbation) data only
+                df_timestamp = np.array(df['timestamp'])
+                df_datetimes = np.array([timestamp2datetime(timestamp) for timestamp in df_timestamp])
+                df_datetime_deltas = np.array(df.timestamp[1:df_size]) - np.array(df.timestamp[0:df_size-1])
+                dt_seconds = np.array([df_datetime_deltas[i].total_seconds() for i in range(df_size-1)])
+                df_dBN_dt = (np.array(df['DeltaB_North'][1:df_size]) 
+                     - np.array(df['DeltaB_North'][0:df_size-1]))/dt_seconds
+                df_dBE_dt = (np.array(df['DeltaB_East'][1:df_size]) 
+                     - np.array(df['DeltaB_East'][0:df_size-1]))/dt_seconds
+                df_datetimes=np.array(df.index[0:df_size-1]) + df_datetime_deltas/2
+        df_dbH_dt = pd.DataFrame(np.sqrt(df_dBN_dt*df_dBN_dt+df_dBE_dt*df_dBE_dt),
+	                         columns=['dBH_dt'], index=df_datetimes)
+        return(df_dbH_dt)
 
 
 def rmsScore(modDF, obsDF):
@@ -232,6 +268,17 @@ def truePostiveRate(mod, obs, threshold):
 	ct = contingencyTable(mod, obs, threshold)
 	return ct['tp'] / (ct['tp'] + ct['fn'])
 
+def truePostiveRate_from_ct(ct):
+	'''
+    Computes true positive rate based on contingency table
+            Parameters:
+                    ct (pandas.DataFrame): contingecny table with true positive (tp)
+                        and false negative (fn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+    '''
+	return ct['tp'] / (ct['tp'] + ct['fn'])
+
 def falsePostiveRate(mod, obs, threshold):
 	'''
     Computes false positive rate based on modDF and obsDF.  
@@ -249,6 +296,17 @@ def falsePostiveRate(mod, obs, threshold):
 	ct = contingencyTable(mod, obs, threshold)
 	return ct['fp'] / (ct['fp'] + ct['tn'])
 
+def falsePostiveRate_from_ct(ct):
+	'''
+    Computes false positive rate based on contingency table 
+    
+            Parameters:
+                    ct: contingency table with false positive (fp) and true negative (tn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+    '''
+	return ct['fp'] / (ct['fp'] + ct['tn'])
+
 def threatScore(mod, obs, threshold):
 	'''
     Computes threat score based on modDF and obsDF.  
@@ -264,6 +322,17 @@ def threatScore(mod, obs, threshold):
     '''
 	obs = obs.reindex(mod.index)
 	ct = contingencyTable(mod, obs, threshold)
+	return ct['tp'] / (ct['tp'] + ct['fp'] + ct['fn'])
+
+def threatScore_from_ct(ct):
+	'''
+    Computes threat score based on contingency table calculated from modDF and obsDF.  
+            Parameters:
+                    ct: contingency table with true positive (tp), false positive (fp)
+                        and false negative (fn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+    '''
 	return ct['tp'] / (ct['tp'] + ct['fp'] + ct['fn'])
 
 def trueSkillStatistics(mod, obs, threshold):
@@ -300,6 +369,71 @@ def bias(mod, obs, threshold):
 	ct = contingencyTable(mod, obs, threshold)
 	return (ct['tp'] + ct['fp']) / (ct['tp'] + ct['fn'])
 
+def bias_from_ct(ct):
+        '''
+    Computes bias based on contingency table
+       
+            Parameters:
+                    ct: contingency table with true positive (tp) and false negative (fn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+        '''
+        return (ct['tp'] + ct['fp']) / (ct['tp'] + ct['fn'])
+
+def pod_from_ct(ct):
+        '''
+    Computes Probability of Detection based on contingency table
+       
+            Parameters:
+                    ct: contingency table with true positive (tp) and false negative (fn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+        '''
+        return (ct['tp']) / (ct['tp'] + ct['fn'])
+
+def pofd_from_ct(ct):
+        '''
+    Computes Probability of False Detection based on contingency table
+       
+            Parameters:
+                    ct - contingency table with false positive (fp) and true negative (tn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+        '''
+        return (ct['fp']) / (ct['fp'] + ct['tn'])
+
+def HeidkeScore(ct):
+        '''
+    Computes Heidke Skill Score based on modDF and obsDF.  
+            Parameters:
+                    modDF (pandas.DataFrame): dataframe with datatime as index
+                    obsDF (pandas.DataFrame): dataframe with datatime as index
+		    		threshold (float): threshold to determine an 'event'
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+        '''
+        obs = obs.reindex(mod.index)
+        ct = contingencyTable(mod, obs, threshold)
+        h = ct['tp']
+        f = ct['fp']
+        m = ct['fn']
+        n = ct['tn']       
+        return (2 * (h * n - m * f)/( (h + m) * (m + n) + (h + f) * (f + n) ) )
+
+def HeidkeScore_from_ct(ct):
+        '''
+    Computes Heidke Skill Score based on contingency table
+            Parameters:
+                    ct: contingency table with true positive (tp), false positive (fp),
+                        false negative (fn) and true negative (tn) counts
+            Returns:
+                    score (pandas.Series): series with parameter name(s) as index
+        '''
+        h = ct['tp']
+        f = ct['fp']
+        m = ct['fn']
+        n = ct['tn']       
+        return (2 * (h * n - m * f)/( (h + m) * (m + n) + (h + f) * (f + n) ) )
 
 # internal charging metrics
 # Median symmetric accuracy 
@@ -435,7 +569,7 @@ def contingencyTable(mod, obs, threshold):
 	return df
 
 
-def contingencyTable_with_timewindows(mod, obs, threshold, windowlength):
+def contingencyTable_with_timewindows(mod, obs, threshold, windowlength,use_obs_times=False,use_model_times=False,debug=False):
 	'''
     Computes contingency table. Helper function.  Columns returned include
     true positive, false positive, false negative, and true negative
@@ -457,8 +591,15 @@ def contingencyTable_with_timewindows(mod, obs, threshold, windowlength):
 	t1o = obs.index[-1]
 	t0 = min([t0m,t0o])
 	t1 = max([t1m,t1o])
+	if use_obs_times:
+		t0 = t0o
+		t1 = t1o
+	if use_model_times:
+		t0 = t0m
+		t1 = t1m
 	dt = timedelta(minutes=windowlength)
-	n_dt = int((t1-t0)/dt)+1
+	n_dt = int(np.ceil((t1-t0)/dt))
+	print('t1-t0: ',t1-t0,' dt: ',dt,' number of windows: ',n_dt)
     
 	eventMod = np.full(n_dt,0)
 	for i in range(n_dt):
@@ -471,6 +612,8 @@ def contingencyTable_with_timewindows(mod, obs, threshold, windowlength):
 		t0_ = t0 + i*dt
 		t1_ = t0 +(i+1)*dt
 		eventObs[i] = np.any(obs[ np.logical_and(obs.index >= t0_, obs.index < t1_) == True ] > threshold)
+	if debug:
+		print("OY ON",np.sum(eventObs),n_dt-np.sum(eventObs))
 
 	tp = sum(eventMod + eventObs == 2)
 	fp = sum(eventMod) - tp


### PR DESCRIPTION
contingencyTable_with_timewindows takes the window length (in minutes) as an additional required argument.
I also added functions to compute skills (POD, POFD, Heidke Skill) from contingency tables instead of from the original dataframes.